### PR TITLE
coverage: coverage all containers, unify reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,8 @@ jobs:
       - run: docker-compose exec api sh -c "pip freeze"
       - run: docker-compose exec api sh -c "apt list --installed"
       - run: logger -n 127.0.0.1 -P 5515 --tcp going_to_install_migrations_with_make_migrations
+      - run: docker-compose exec api sh -c "echo \"import coverage\" >> /usr/local/lib/python3.8/sitecustomize.py && echo \"coverage.process_startup()\" >> /usr/local/lib/python3.8/sitecustomize.py"
+      - run: docker-compose restart api
       - run: docker-compose exec api sh -c "coverage --version && coverage run --data-file=/coverage/.coverage.migrations /daas/manage.py makemigrations daas_app" && date
       - run: logger -n 127.0.0.1 -P 5515 --tcp going_to_execute_migrate
       - run: docker-compose exec api sh -c "coverage run --data-file=/coverage/.coverage.migrations2 /daas/manage.py migrate" && date

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,12 +64,12 @@ jobs:
       - run: logger -n 127.0.0.1 -P 5515 --tcp going_to_execute_metadata_extractor_tests
       - run:
           name: executing metadata extractor tests
-          command: docker-compose exec meta_extractor_worker sh -c "pip install pytest==5.2.1 pytest-cov==2.8.1 && coverage run --data-file=/coverage/.coverage.meta_extractor pytest /daas/tests/" && date
+          command: docker-compose exec meta_extractor_worker sh -c "pip install pytest==5.2.1 pytest-cov==2.8.1 && coverage run --data-file=/coverage/.coverage.meta_extractor /usr/local/bin/pytest /daas/tests/" && date
       - run: logger -n 127.0.0.1 -P 5515 --tcp going_to_execute_decompilers_tests
       - run:
           name: executing decompilers tests
           # command: docker-compose exec pe_worker sh -c "pip install pytest==5.2.1 pytest-cov==2.8.1 && pytest --cov-report term-missing --cov-config=/daas/.covconf --cov=daas /daas/tests/ --cov-fail-under=45" && date
-          command: docker-compose exec pe_worker sh -c "pip install pytest==5.2.1 pytest-cov==2.8.1 && coverage run --data-file=/coverage/.coverage.decompilers pytest /daas/tests/" && date
+          command: docker-compose exec pe_worker sh -c "pip install pytest==5.2.1 pytest-cov==2.8.1 && coverage run --data-file=/coverage/.coverage.decompilers /usr/local/bin/pytest /daas/tests/" && date
       - run:
           name: print logs on fail after decompilers tests
           command: docker-compose exec syslog cat /var/log/messages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - run:
           name: executing coverage
           # containers running coverage have to be cleanly stopped so that subprocesses save the coverage data
-          command: docker-compose stop api pe_worker flash_worker java_worker apk_worker meta_extractor_worker && docker-compose up -d coverage && docker-compose exec coverage bash -c "cd /coverage && ls -la && md5sum *.* &&  coverage combine --debug=pathmap --rcfile=/daas/.coveragerc && coverage report --rcfile=/daas/.coveragerc -m && coverage html --rcfile=/daas/.coveragerc" && date
+          command: docker-compose stop api pe_worker flash_worker java_worker apk_worker meta_extractor_worker && docker-compose up -d coverage && docker-compose exec coverage bash -c "cd /coverage && ls -la && md5sum .* ; coverage combine --debug=pathmap --rcfile=/daas/.coveragerc && coverage report --rcfile=/daas/.coveragerc -m && coverage html --rcfile=/daas/.coveragerc" && date
           when: always
       - run:
           name: Compress logs on messages.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,11 +64,12 @@ jobs:
       - run: logger -n 127.0.0.1 -P 5515 --tcp going_to_execute_metadata_extractor_tests
       - run:
           name: executing metadata extractor tests
-          command: docker-compose exec meta_extractor_worker sh -c "pip install pytest==5.2.1 pytest-cov==2.8.1 && pytest --cov-report term-missing --cov-config=/daas/.covconf --cov=daas /daas/tests/ --cov-fail-under=75" && date
+          command: docker-compose exec meta_extractor_worker sh -c "pip install pytest==5.2.1 pytest-cov==2.8.1 && coverage run --data-file=/coverage/.coverage.meta_extractor pytest /daas/tests/" && date
       - run: logger -n 127.0.0.1 -P 5515 --tcp going_to_execute_decompilers_tests
       - run:
           name: executing decompilers tests
-          command: docker-compose exec pe_worker sh -c "pip install pytest==5.2.1 pytest-cov==2.8.1 && pytest --cov-report term-missing --cov-config=/daas/.covconf --cov=daas /daas/tests/ --cov-fail-under=45" && date
+          # command: docker-compose exec pe_worker sh -c "pip install pytest==5.2.1 pytest-cov==2.8.1 && pytest --cov-report term-missing --cov-config=/daas/.covconf --cov=daas /daas/tests/ --cov-fail-under=45" && date
+          command: docker-compose exec pe_worker sh -c "pip install pytest==5.2.1 pytest-cov==2.8.1 && coverage run --data-file=/coverage/.coverage.decompilers pytest /daas/tests/" && date
       - run:
           name: print logs on fail after decompilers tests
           command: docker-compose exec syslog cat /var/log/messages

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
           when: on_fail
       - run:
           name: executing coverage
-          command: docker-compose exec api sh -c "cd /coverage && coverage --debug=pathmap combine && coverage report -m && coverage html" && date
+          command: docker-compose exec api sh -c "cd /coverage && coverage combine --debug=pathmap && coverage report -m && coverage html" && date
           when: always
       - run:
           name: Compress logs on messages.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
       - run: docker-compose exec api sh -c "pip freeze"
       - run: docker-compose exec api sh -c "apt list --installed"
       - run: logger -n 127.0.0.1 -P 5515 --tcp going_to_install_migrations_with_make_migrations
-      - run: docker-compose exec api sh -c "coverage run --data-file=/coverage/.coverage.migrations /daas/manage.py makemigrations daas_app" && date
+      - run: docker-compose exec api sh -c "coverage --version && coverage run --data-file=/coverage/.coverage.migrations /daas/manage.py makemigrations daas_app" && date
       - run: logger -n 127.0.0.1 -P 5515 --tcp going_to_execute_migrate
       - run: docker-compose exec api sh -c "coverage run --data-file=/coverage/.coverage.migrations2 /daas/manage.py migrate" && date
       - run: logger -n 127.0.0.1 -P 5515 --tcp going_to_execute_api_tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,12 @@ jobs:
           name: Build Java worker
           command: docker-compose build java_worker
       - run:
+          name: Build coverage image
+          command: docker-compose build coverage
+      - run:
           command: docker-compose up -d seaweedfs_master seaweedfs_volume seaweedfs_filer redis_task_queue
       - run:
-          command: sleep 35 && docker-compose up -d
+          command: sleep 35 && docker-compose up -d api redis_statistics meta_extractor_worker pe_worker flash_worker java_worker apk_worker nginx
       - run: sleep 10 && free -h && docker-compose ps
       - run:
           name: check containers. If at least one is down, print logs
@@ -89,7 +92,7 @@ jobs:
           when: on_fail
       - run:
           name: executing coverage
-          command: docker-compose exec api sh -c "cd /coverage && coverage combine --debug=pathmap && coverage report --ignore-errors -m && coverage html --ignore-errors" && date
+          command: docker-compose up coverage && date
           when: always
       - run:
           name: Compress logs on messages.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,12 +67,12 @@ jobs:
       - run: logger -n 127.0.0.1 -P 5515 --tcp going_to_execute_metadata_extractor_tests
       - run:
           name: executing metadata extractor tests
-          command: docker-compose exec meta_extractor_worker sh -c "pip install pytest==5.2.1 pytest-cov==2.8.1 && coverage run --data-file=/coverage/.coverage.meta_extractor /usr/local/bin/pytest /daas/tests/" && date
+          command: docker-compose exec meta_extractor_worker sh -c "pip install pytest==5.2.1 pytest-cov==2.8.1 && coverage run --module --data-file=/coverage/.coverage.meta_extractor pytest /daas/tests/" && date
       - run: logger -n 127.0.0.1 -P 5515 --tcp going_to_execute_decompilers_tests
       - run:
           name: executing decompilers tests
           # command: docker-compose exec pe_worker sh -c "pip install pytest==5.2.1 pytest-cov==2.8.1 && pytest --cov-report term-missing --cov-config=/daas/.covconf --cov=daas /daas/tests/ --cov-fail-under=45" && date
-          command: docker-compose exec pe_worker sh -c "pip install pytest==5.2.1 pytest-cov==2.8.1 && coverage run --data-file=/coverage/.coverage.decompilers /usr/local/bin/pytest /daas/tests/" && date
+          command: docker-compose exec pe_worker sh -c "pip install pytest==5.2.1 pytest-cov==2.8.1 && coverage run --module --data-file=/coverage/.coverage.decompilers pytest /daas/tests/" && date
       - run:
           name: print logs on fail after decompilers tests
           command: docker-compose exec syslog cat /var/log/messages
@@ -92,7 +92,7 @@ jobs:
           when: on_fail
       - run:
           name: executing coverage
-          command: docker-compose up coverage && date
+          command: docker-compose up -d coverage && docker-compose exec coverage bash -c "cd /coverage && coverage combine --debug=pathmap --rcfile=/daas/.coveragerc && coverage report --rcfile=/daas/.coveragerc -m && coverage html --rcfile=/daas/.coveragerc" && date
           when: always
       - run:
           name: Compress logs on messages.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
           when: on_fail
       - run:
           name: executing coverage
-          command: docker-compose exec api sh -c "cd /coverage && coverage combine --debug=pathmap && coverage report -m && coverage html" && date
+          command: docker-compose exec api sh -c "cd /coverage && coverage combine --debug=pathmap && coverage report --ignore-errors -m && coverage html --ignore-errors" && date
           when: always
       - run:
           name: Compress logs on messages.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,7 +95,7 @@ jobs:
       - run:
           name: executing coverage
           # api has to be stopped so that gunicorn subprocesses save the coverage data
-          command: docker-compose stop api && docker-compose up -d coverage && docker-compose exec coverage bash -c "cd /coverage && coverage combine --debug=pathmap --rcfile=/daas/.coveragerc && coverage report --rcfile=/daas/.coveragerc -m && coverage html --rcfile=/daas/.coveragerc" && date
+          command: docker-compose stop api && docker-compose up -d coverage && docker-compose exec coverage bash -c "cd /coverage && ls -la && coverage combine --debug=pathmap --rcfile=/daas/.coveragerc && coverage report --rcfile=/daas/.coveragerc -m && coverage html --rcfile=/daas/.coveragerc" && date
           when: always
       - run:
           name: Compress logs on messages.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - run:
           name: executing coverage
           # containers running coverage have to be cleanly stopped so that subprocesses save the coverage data
-          command: docker-compose stop api pe_worker flash_worker java_worker apk_worker meta_extractor_worker && docker-compose up -d coverage && docker-compose exec coverage bash -c "cd /coverage && ls -la && md5sum .* &&  coverage combine --debug=pathmap --rcfile=/daas/.coveragerc && coverage report --rcfile=/daas/.coveragerc -m && coverage html --rcfile=/daas/.coveragerc" && date
+          command: docker-compose stop api pe_worker flash_worker java_worker apk_worker meta_extractor_worker && docker-compose up -d coverage && docker-compose exec coverage bash -c "cd /coverage && ls -la && md5sum *.* &&  coverage combine --debug=pathmap --rcfile=/daas/.coveragerc && coverage report --rcfile=/daas/.coveragerc -m && coverage html --rcfile=/daas/.coveragerc" && date
           when: always
       - run:
           name: Compress logs on messages.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,8 @@ jobs:
           when: on_fail
       - run:
           name: executing coverage
-          command: docker-compose up -d coverage && docker-compose exec coverage bash -c "cd /coverage && coverage combine --debug=pathmap --rcfile=/daas/.coveragerc && coverage report --rcfile=/daas/.coveragerc -m && coverage html --rcfile=/daas/.coveragerc" && date
+          # api has to be stopped so that gunicorn subprocesses save the coverage data
+          command: docker-compose stop api && docker-compose up -d coverage && docker-compose exec coverage bash -c "cd /coverage && coverage combine --debug=pathmap --rcfile=/daas/.coveragerc && coverage report --rcfile=/daas/.coveragerc -m && coverage html --rcfile=/daas/.coveragerc" && date
           when: always
       - run:
           name: Compress logs on messages.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - run:
           name: executing coverage
           # containers running coverage have to be cleanly stopped so that subprocesses save the coverage data
-          command: docker-compose stop api pe_worker flash_worker java_worker apk_worker meta_extractor_worker && docker-compose up -d coverage && docker-compose exec coverage bash -c "cd /coverage && ls -la && coverage combine --debug=pathmap --rcfile=/daas/.coveragerc && coverage report --rcfile=/daas/.coveragerc -m && coverage html --rcfile=/daas/.coveragerc" && date
+          command: docker-compose stop api pe_worker flash_worker java_worker apk_worker meta_extractor_worker && docker-compose up -d coverage && docker-compose exec coverage bash -c "cd /coverage && ls -la && md5sum * &&  coverage combine --debug=pathmap --rcfile=/daas/.coveragerc && coverage report --rcfile=/daas/.coveragerc -m && coverage html --rcfile=/daas/.coveragerc" && date
           when: always
       - run:
           name: Compress logs on messages.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,7 +112,7 @@ jobs:
       - run:
           name: executing coverage
           # containers running coverage have to be cleanly stopped so that subprocesses save the coverage data
-          command: docker-compose stop api pe_worker flash_worker java_worker apk_worker meta_extractor_worker && docker-compose up -d coverage && docker-compose exec coverage bash -c "cd /coverage && ls -la && md5sum * &&  coverage combine --debug=pathmap --rcfile=/daas/.coveragerc && coverage report --rcfile=/daas/.coveragerc -m && coverage html --rcfile=/daas/.coveragerc" && date
+          command: docker-compose stop api pe_worker flash_worker java_worker apk_worker meta_extractor_worker && docker-compose up -d coverage && docker-compose exec coverage bash -c "cd /coverage && ls -la && md5sum .* &&  coverage combine --debug=pathmap --rcfile=/daas/.coveragerc && coverage report --rcfile=/daas/.coveragerc -m && coverage html --rcfile=/daas/.coveragerc" && date
           when: always
       - run:
           name: Compress logs on messages.zip

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,17 +46,17 @@ jobs:
       - run: docker-compose exec api sh -c "pip freeze"
       - run: docker-compose exec api sh -c "apt list --installed"
       - run: logger -n 127.0.0.1 -P 5515 --tcp going_to_install_migrations_with_make_migrations
-      - run: docker-compose exec api sh -c "python -u /daas/manage.py makemigrations daas_app" && date
+      - run: docker-compose exec api sh -c "coverage run --data-file=/coverage/.coverage.migrations /daas/manage.py makemigrations daas_app" && date
       - run: logger -n 127.0.0.1 -P 5515 --tcp going_to_execute_migrate
-      - run: docker-compose exec api sh -c "python -u /daas/manage.py migrate" && date
+      - run: docker-compose exec api sh -c "coverage run --data-file=/coverage/.coverage.migrations2 /daas/manage.py migrate" && date
       - run: logger -n 127.0.0.1 -P 5515 --tcp going_to_execute_api_tests
       - run:
           name: executing api tests
-          command: docker-compose exec api sh -c "coverage run --source='/daas/daas_app' /daas/manage.py test daas_app.tests.unit_tests -v 1 --force-color --exclude stress_test_csharp --noinput" && date
+          command: docker-compose exec api sh -c "coverage run --data-file=/coverage/.coverage.api_tests /daas/manage.py test daas_app.tests.unit_tests -v 1 --force-color --exclude stress_test_csharp --noinput" && date
       - run: logger -n 127.0.0.1 -P 5515 --tcp going_to_execute_reversed_api_tests
       - run:
           name: executing api tests in reverse order
-          command: docker-compose exec api sh -c "python -u /daas/manage.py test daas_app.tests.unit_tests --reverse -v 1 --force-color --exclude stress_test_csharp --noinput" && date
+          command: docker-compose exec api sh -c "coverage run --data-file=/coverage/.coverage.api_tests_reverse /daas/manage.py test daas_app.tests.unit_tests --reverse -v 1 --force-color --exclude stress_test_csharp --noinput" && date
       - run:
           name: print logs on fail after api tests
           command: docker-compose exec syslog cat /var/log/messages
@@ -79,7 +79,7 @@ jobs:
           no_output_timeout: 60m
           command: |
             if [[ ! -z $CI_PULL_REQUEST ]]; then
-               docker-compose exec api sh -c "timeout 3600 python -u /daas/manage.py test daas_app.tests.decompilation_ratio_tests -v 1 --force-color --noinput " && date
+               docker-compose exec api sh -c "timeout 3600 coverage run --data-file=/coverage/.coverage.stress /daas/manage.py test daas_app.tests.decompilation_ratio_tests -v 1 --force-color --noinput " && date
             fi
       - run: logger -n 127.0.0.1 -P 5515 --tcp going_to_print_logs_after_failed_stress_tests
       - run:
@@ -88,7 +88,7 @@ jobs:
           when: on_fail
       - run:
           name: executing coverage
-          command: docker-compose exec api sh -c "coverage report -m --fail-under=70 --omit='*daas_app/tests/*,*daas_app/migrations/*,*daas_app/decompilers*'" && date
+          command: docker-compose exec api sh -c "cd /coverage && coverage --debug=pathmap combine && coverage report -m && coverage html" && date
           when: always
       - run:
           name: Compress logs on messages.zip
@@ -100,3 +100,6 @@ jobs:
       - store_artifacts:
           path: messages.zip
           destination: messages.zip
+      - store_artifacts:
+          path: ../coverage/htmlcov
+          destination: htmlcov

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,25 @@ jobs:
       - run: docker-compose exec api sh -c "pip freeze"
       - run: docker-compose exec api sh -c "apt list --installed"
       - run: logger -n 127.0.0.1 -P 5515 --tcp going_to_install_migrations_with_make_migrations
-      - run: docker-compose exec api sh -c "echo \"import coverage\" >> /usr/local/lib/python3.8/sitecustomize.py && echo \"coverage.process_startup()\" >> /usr/local/lib/python3.8/sitecustomize.py"
-      - run: docker-compose restart api
+      - run: 
+          name: Installing test requirements
+          command: |
+            docker-compose exec pe_worker sh -c "pip install --upgrade pip && pip --retries 10 install -r /tmp/requirements_test.txt"
+            docker-compose exec flash_worker sh -c "pip install --upgrade pip && pip --retries 10 install -r /tmp/requirements_test.txt"
+            docker-compose exec java_worker sh -c "pip install --upgrade pip && pip --retries 10 install -r /tmp/requirements_test.txt"
+            docker-compose exec apk_worker sh -c "pip install --upgrade pip && pip --retries 10 install -r /tmp/requirements_test.txt"
+            docker-compose exec meta_extractor_worker sh -c "pip install --upgrade pip && pip --retries 10 install -r /tmp/requirements_test.txt"
+      - run: 
+          name: Saving coverage settings on api and workers
+          command: |
+            docker-compose exec api sh -c "echo \"import coverage\" >> /usr/local/lib/python3.8/sitecustomize.py && echo \"coverage.process_startup()\" >> /usr/local/lib/python3.8/sitecustomize.py"
+            docker-compose exec pe_worker sh -c "echo \"import coverage\" >> /usr/local/lib/python3.7/sitecustomize.py && echo \"coverage.process_startup()\" >> /usr/local/lib/python3.7/sitecustomize.py"
+            docker-compose exec flash_worker sh -c "echo \"import coverage\" >> /usr/local/lib/python3.7/sitecustomize.py && echo \"coverage.process_startup()\" >> /usr/local/lib/python3.7/sitecustomize.py"
+            docker-compose exec java_worker sh -c "echo \"import coverage\" >> /usr/local/lib/python3.7/sitecustomize.py && echo \"coverage.process_startup()\" >> /usr/local/lib/python3.7/sitecustomize.py"
+            docker-compose exec apk_worker sh -c "echo \"import coverage\" >> /usr/local/lib/python3.7/sitecustomize.py && echo \"coverage.process_startup()\" >> /usr/local/lib/python3.7/sitecustomize.py"
+            # note meta_extractor_worker has python 3.8. Not 3.7
+            docker-compose exec meta_extractor_worker sh -c "echo \"import coverage\" >> /usr/local/lib/python3.8/sitecustomize.py && echo \"coverage.process_startup()\" >> /usr/local/lib/python3.8/sitecustomize.py"
+      - run: docker-compose restart api pe_worker flash_worker java_worker apk_worker meta_extractor_worker
       - run: docker-compose exec api sh -c "coverage --version && coverage run --data-file=/coverage/.coverage.migrations /daas/manage.py makemigrations daas_app" && date
       - run: logger -n 127.0.0.1 -P 5515 --tcp going_to_execute_migrate
       - run: docker-compose exec api sh -c "coverage run --data-file=/coverage/.coverage.migrations2 /daas/manage.py migrate" && date

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -111,8 +111,8 @@ jobs:
           when: on_fail
       - run:
           name: executing coverage
-          # api has to be stopped so that gunicorn subprocesses save the coverage data
-          command: docker-compose stop api && docker-compose up -d coverage && docker-compose exec coverage bash -c "cd /coverage && ls -la && coverage combine --debug=pathmap --rcfile=/daas/.coveragerc && coverage report --rcfile=/daas/.coveragerc -m && coverage html --rcfile=/daas/.coveragerc" && date
+          # containers running coverage have to be cleanly stopped so that subprocesses save the coverage data
+          command: docker-compose stop api pe_worker flash_worker java_worker apk_worker meta_extractor_worker && docker-compose up -d coverage && docker-compose exec coverage bash -c "cd /coverage && ls -la && coverage combine --debug=pathmap --rcfile=/daas/.coveragerc && coverage report --rcfile=/daas/.coveragerc -m && coverage html --rcfile=/daas/.coveragerc" && date
           when: always
       - run:
           name: Compress logs on messages.zip

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[paths]
+# We need this so that coverage can find the source code
+# when doing the report.
+asdf =
+    /daas/decompilers/
+    /decompilers/
+asdf2 =
+    /daas/meta_extractor/
+    /meta_extractor/

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,7 @@
 [paths]
+# When exeuting tests in different
+# containers, we do not mount the whole repo, but specific
+# folders.
 # We need this so that coverage can find the source code
 # when doing the report.
 asdf =
@@ -7,3 +10,6 @@ asdf =
 asdf2 =
     /daas/meta_extractor/
     /meta_extractor/
+asdf3 =
+    /daas/daas/daas/
+    /daas/daas/

--- a/.coveragerc
+++ b/.coveragerc
@@ -4,7 +4,6 @@
 # folders.
 # We need this so that coverage can find the source code
 # when doing the report.
-# 'asdf3' and 'asfd4' could be on the same line?
 asdf =
     /daas/decompilers/
     /decompilers/
@@ -12,8 +11,5 @@ asdf2 =
     /daas/meta_extractor/
     /meta_extractor/
 asdf3 =
-    /daas/daas/daas/
     /daas/daas/
-asdf4 =
-    /daas/daas/daas_app/
-    /daas/daas_app/
+    /daas/

--- a/.coveragerc
+++ b/.coveragerc
@@ -4,6 +4,7 @@
 # folders.
 # We need this so that coverage can find the source code
 # when doing the report.
+# 'asdf3' and 'asfd4' could be on the same line?
 asdf =
     /daas/decompilers/
     /decompilers/
@@ -13,3 +14,6 @@ asdf2 =
 asdf3 =
     /daas/daas/daas/
     /daas/daas/
+asdf4 =
+    /daas/daas/daas_app/
+    /daas/daas_app/

--- a/apkWorkerDockerfile
+++ b/apkWorkerDockerfile
@@ -2,6 +2,7 @@ FROM python:3.7.4-buster
 RUN mkdir /decompilers
 WORKDIR /decompilers
 COPY requirements_worker.txt /tmp/requirements_worker.txt
+COPY requirements_test.txt /tmp/requirements_test.txt
 RUN pip install --upgrade pip && \
     pip --retries 10 install -r /tmp/requirements_worker.txt
 

--- a/apkWorkerDockerfile
+++ b/apkWorkerDockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7.4-buster
-RUN mkdir /daas
-WORKDIR /daas
+RUN mkdir /decompilers
+WORKDIR /decompilers
 COPY requirements_worker.txt /tmp/requirements_worker.txt
 RUN pip install --upgrade pip && \
     pip --retries 10 install -r /tmp/requirements_worker.txt
@@ -58,3 +58,5 @@ RUN echo "Installing java decompilers" && \
     rm -rf jd-cli-0.9.1.Final-dist.zip && \
     cd ../ && \
     echo "jd-cli installed"
+
+RUN ln -Ts /decompilers/ /daas

--- a/coverageDockerfile
+++ b/coverageDockerfile
@@ -1,0 +1,7 @@
+FROM python:3.8.0-buster AS base
+RUN mkdir /daas
+WORKDIR /daas
+# Install testing pip packages
+COPY requirements_test.txt /tmp/requirements_test.txt
+RUN pip install --upgrade pip && \
+    pip --retries 10 install -r /tmp/requirements_test.txt

--- a/daas/cov_subprocess
+++ b/daas/cov_subprocess
@@ -1,0 +1,3 @@
+[run]
+parallel = True
+data_file = ../coverage/.coverage_subprocess

--- a/decompilers/.covconf
+++ b/decompilers/.covconf
@@ -1,5 +1,0 @@
-[run]
-omit =
-    tests/*
-    worker.py
-    __init__.py

--- a/decompilers/coverage_decompiler_apk
+++ b/decompilers/coverage_decompiler_apk
@@ -1,0 +1,3 @@
+[run]
+parallel = True
+data_file = ../coverage/.coverage_decompiler_apk

--- a/decompilers/coverage_decompiler_flash
+++ b/decompilers/coverage_decompiler_flash
@@ -1,0 +1,3 @@
+[run]
+parallel = True
+data_file = ../coverage/.coverage_decompiler_flash

--- a/decompilers/coverage_decompiler_java
+++ b/decompilers/coverage_decompiler_java
@@ -1,0 +1,3 @@
+[run]
+parallel = True
+data_file = ../coverage/.coverage_decompiler_java

--- a/decompilers/coverage_decompiler_pe
+++ b/decompilers/coverage_decompiler_pe
@@ -1,0 +1,3 @@
+[run]
+parallel = True
+data_file = ../coverage/.coverage_decompiler_pe

--- a/decompilers/decompiler.py
+++ b/decompilers/decompiler.py
@@ -158,7 +158,7 @@ class SubprocessBasedDecompiler(AbstractDecompiler):
 
     def start_new_argument(self, split_command, argument):
         argument = argument.strip()
-        if argument is not '':
+        if argument != '':
             split_command.append(argument)
         return ''
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - /daas/daas_app/tests/resources/ # to not mount tests resources
       - ./static:/static
       - ./gunicorn_config/:/home/root/conf
+      - ../coverage/:/coverage/
     expose:
       - "8001"
       - "4567-4667"
@@ -83,6 +84,7 @@ services:
     command: bash -c "rq worker --path / --url redis://daas_redis_task_queue_1:6379/0 unknown unknown_requeued --name agent_$$(hostname -I | cut -d' ' -f1)_$$(echo $$RANDOM)__$$(date +%s)"
     volumes:
       - ./meta_extractor:/daas
+      - ../coverage/:/coverage/
     links:
       - redis_task_queue
       - syslog
@@ -102,6 +104,7 @@ services:
     volumes:
       - ./decompilers:/daas
       - ./utils/just_decompile:/just_decompile/
+      - ../coverage/:/coverage/
     tmpfs:
       - /tmpfs
     links:
@@ -122,6 +125,7 @@ services:
     command: bash -c "rq worker --path / --url redis://daas_redis_task_queue_1:6379/0 flash_queue --name agent_$$(hostname -I | cut -d' ' -f1)_$$(echo $$RANDOM)__$$(date +%s)"
     volumes:
       - ./decompilers:/daas
+      - ../coverage/:/coverage/
     tmpfs:
       - /tmpfs
     links:
@@ -142,6 +146,7 @@ services:
     command: bash -c "rq worker --path / --url redis://daas_redis_task_queue_1:6379/0 java_queue --name agent_$$(hostname -I | cut -d' ' -f1)_$$(echo $$RANDOM)__$$(date +%s)"
     volumes:
       - ./decompilers:/daas
+      - ../coverage/:/coverage/
     tmpfs:
       - /tmpfs
     links:
@@ -162,6 +167,7 @@ services:
     command: bash -c "rq worker --path / --url redis://daas_redis_task_queue_1:6379/0 apk_queue --name agent_$$(hostname -I | cut -d' ' -f1)_$$(echo $$RANDOM)__$$(date +%s)"
     volumes:
       - ./decompilers:/daas
+      - ../coverage/:/coverage/
     tmpfs:
       - /tmpfs
     links:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ services:
       context: .
       target: testing
     command: bash -c "python3 /daas/manage.py collectstatic --no-input && cd /daas/ && gunicorn daas.wsgi --timeout 300 -b 0.0.0.0:8001"
-    stop_signal: SIGINT # django
     volumes:
       - ./daas:/daas
       - /daas/daas_app/tests/resources/ # to not mount tests resources
@@ -23,6 +22,8 @@ services:
       - /tmpfs
     environment:
       - CIRCLECI
+      # coverage will not execute on prod since sitecustomize.py is not modified
+      - COVERAGE_PROCESS_START=/daas/cov_subprocess
     logging:
       driver: syslog
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -265,7 +265,8 @@ services:
     build:
       context: .
       dockerfile: coverageDockerfile
-    command: bash -c "cd /coverage && coverage combine --debug=pathmap && coverage report --ignore-errors -m && coverage html --ignore-errors"
+    command: bash -i
+    stdin_open: true
     volumes:
       - ./:/daas
       - ../coverage/:/coverage/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: .
       target: testing
     command: bash -c "python3 /daas/manage.py collectstatic --no-input && cd /daas/ && gunicorn daas.wsgi --timeout 300 -b 0.0.0.0:8001"
+    stop_signal: SIGINT # django
     volumes:
       - ./daas:/daas
       - /daas/daas_app/tests/resources/ # to not mount tests resources

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -265,7 +265,7 @@ services:
     build:
       context: .
       dockerfile: coverageDockerfile
-    command: bash -c ""
+    command: bash -c "cd /coverage && coverage combine --debug=pathmap && coverage report --ignore-errors -m && coverage html --ignore-errors"
     volumes:
       - ./:/daas
       - ../coverage/:/coverage/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,7 @@ services:
       - syslog
     environment:
       - CIRCLECI
+      - COVERAGE_PROCESS_START=/meta_extractor/coverage_meta_extractor
     logging:
       driver: syslog
       options:
@@ -114,6 +115,7 @@ services:
       - syslog
     environment:
       - CIRCLECI
+      - COVERAGE_PROCESS_START=/decompilers/coverage_decompiler_pe
     logging:
       driver: syslog
       options:
@@ -135,6 +137,7 @@ services:
       - syslog
     environment:
       - CIRCLECI
+      - COVERAGE_PROCESS_START=/decompilers/coverage_decompiler_flash
     logging:
       driver: syslog
       options:
@@ -148,6 +151,7 @@ services:
     command: bash -c "rq worker --path / --url redis://daas_redis_task_queue_1:6379/0 java_queue --name agent_$$(hostname -I | cut -d' ' -f1)_$$(echo $$RANDOM)__$$(date +%s)"
     volumes:
       - ./decompilers:/decompilers
+      - COVERAGE_PROCESS_START=/decompilers/coverage_decompiler_java
       - ../coverage/:/coverage/
     tmpfs:
       - /tmpfs
@@ -177,6 +181,7 @@ services:
       - syslog
     environment:
       - CIRCLECI
+      - COVERAGE_PROCESS_START=/decompilers/coverage_decompiler_apk
     logging:
       driver: syslog
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       dockerfile: peWorkerDockerfile
     command: bash -c "rq worker --path / --url redis://daas_redis_task_queue_1:6379/0 pe_queue --name agent_$$(hostname -I | cut -d' ' -f1)_$$(echo $$RANDOM)__$$(date +%s)"
     volumes:
-      - ./decompilers:/daas
+      - ./decompilers:/decompilers
       - ./utils/just_decompile:/just_decompile/
       - ../coverage/:/coverage/
     tmpfs:
@@ -124,7 +124,7 @@ services:
       dockerfile: flashWorkerDockerfile
     command: bash -c "rq worker --path / --url redis://daas_redis_task_queue_1:6379/0 flash_queue --name agent_$$(hostname -I | cut -d' ' -f1)_$$(echo $$RANDOM)__$$(date +%s)"
     volumes:
-      - ./decompilers:/daas
+      - ./decompilers:/decompilers
       - ../coverage/:/coverage/
     tmpfs:
       - /tmpfs
@@ -145,7 +145,7 @@ services:
       dockerfile: javaWorkerDockerfile
     command: bash -c "rq worker --path / --url redis://daas_redis_task_queue_1:6379/0 java_queue --name agent_$$(hostname -I | cut -d' ' -f1)_$$(echo $$RANDOM)__$$(date +%s)"
     volumes:
-      - ./decompilers:/daas
+      - ./decompilers:/decompilers
       - ../coverage/:/coverage/
     tmpfs:
       - /tmpfs
@@ -166,7 +166,7 @@ services:
       dockerfile: apkWorkerDockerfile
     command: bash -c "rq worker --path / --url redis://daas_redis_task_queue_1:6379/0 apk_queue --name agent_$$(hostname -I | cut -d' ' -f1)_$$(echo $$RANDOM)__$$(date +%s)"
     volumes:
-      - ./decompilers:/daas
+      - ./decompilers:/decompilers
       - ../coverage/:/coverage/
     tmpfs:
       - /tmpfs
@@ -260,3 +260,19 @@ services:
       options:
         syslog-address: "udp://127.0.0.1:5515"
         tag: "seaweedfs_filer"
+
+  coverage:
+    build:
+      context: .
+      dockerfile: coverageDockerfile
+    command: bash -c ""
+    volumes:
+      - ./:/daas
+      - ../coverage/:/coverage/
+    links:
+      - syslog
+    logging:
+      driver: syslog
+      options:
+        syslog-address: "udp://127.0.0.1:5515"
+        tag: "coverage"

--- a/flashWorkerDockerfile
+++ b/flashWorkerDockerfile
@@ -2,6 +2,7 @@ FROM python:3.7.4-stretch
 RUN mkdir /decompilers
 WORKDIR /decompilers
 COPY requirements_worker.txt /tmp/requirements_worker.txt
+COPY requirements_test.txt /tmp/requirements_test.txt
 RUN pip install --upgrade pip && \
     pip --retries 10 install -r /tmp/requirements_worker.txt
 

--- a/flashWorkerDockerfile
+++ b/flashWorkerDockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7.4-stretch
-RUN mkdir /daas
-WORKDIR /daas
+RUN mkdir /decompilers
+WORKDIR /decompilers
 COPY requirements_worker.txt /tmp/requirements_worker.txt
 RUN pip install --upgrade pip && \
     pip --retries 10 install -r /tmp/requirements_worker.txt
@@ -51,3 +51,5 @@ RUN wget -nv --no-check-certificate https://github.com/jindrapetrik/jpexs-decomp
     rm -f /tmp/ffdec.deb && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
+
+RUN ln -Ts /decompilers/ /daas

--- a/javaWorkerDockerfile
+++ b/javaWorkerDockerfile
@@ -2,6 +2,7 @@ FROM python:3.7.4-buster
 RUN mkdir /decompilers
 WORKDIR /decompilers
 COPY requirements_worker.txt /tmp/requirements_worker.txt
+COPY requirements_test.txt /tmp/requirements_test.txt
 RUN pip install --upgrade pip && \
     pip --retries 10 install -r /tmp/requirements_worker.txt
 

--- a/javaWorkerDockerfile
+++ b/javaWorkerDockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7.4-buster
-RUN mkdir /daas
-WORKDIR /daas
+RUN mkdir /decompilers
+WORKDIR /decompilers
 COPY requirements_worker.txt /tmp/requirements_worker.txt
 RUN pip install --upgrade pip && \
     pip --retries 10 install -r /tmp/requirements_worker.txt
@@ -38,3 +38,5 @@ RUN echo "installing cfr..." && \
     mkdir /cfr && \
     wget https://www.benf.org/other/cfr/cfr-0.148.jar -O /cfr/cfr.jar && \
     echo "cfr installed"
+
+RUN ln -Ts /decompilers/ /daas

--- a/metaExtractorWorkerDockerfile
+++ b/metaExtractorWorkerDockerfile
@@ -1,6 +1,8 @@
 FROM python:3.8.0-buster
-RUN mkdir /daas
-WORKDIR /daas
+RUN mkdir /meta_extractor
+WORKDIR /meta_extractor
 COPY requirements_worker.txt /tmp/requirements_worker.txt
 RUN pip install --upgrade pip && \
     pip --retries 10 install -r /tmp/requirements_worker.txt
+
+RUN ln -Ts /meta_extractor/ /daas

--- a/metaExtractorWorkerDockerfile
+++ b/metaExtractorWorkerDockerfile
@@ -2,6 +2,7 @@ FROM python:3.8.0-buster
 RUN mkdir /meta_extractor
 WORKDIR /meta_extractor
 COPY requirements_worker.txt /tmp/requirements_worker.txt
+COPY requirements_test.txt /tmp/requirements_test.txt
 RUN pip install --upgrade pip && \
     pip --retries 10 install -r /tmp/requirements_worker.txt
 

--- a/meta_extractor/.covconf
+++ b/meta_extractor/.covconf
@@ -1,5 +1,0 @@
-[run]
-omit =
-    tests/*
-    worker.py
-    __init__.py

--- a/meta_extractor/coverage_meta_extractor
+++ b/meta_extractor/coverage_meta_extractor
@@ -1,0 +1,3 @@
+[run]
+parallel = True
+data_file = ../coverage/.coverage_meta_extractor

--- a/peWorkerDockerfile
+++ b/peWorkerDockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7.4-stretch
-RUN mkdir /daas
-WORKDIR /daas
+RUN mkdir /decompilers
+WORKDIR /decompilers
 ENV HOME /home/root
 COPY requirements_worker.txt /tmp/requirements_worker.txt
 RUN pip install --upgrade pip && \
@@ -67,3 +67,4 @@ RUN echo "Installing Dotnet45" && \
     echo "Dotnet45 installed"
 RUN xvfb-run winetricks -q vcrun2010 && \
     echo "vcrun2010 installed"
+RUN ln -Ts /decompilers/ /daas

--- a/peWorkerDockerfile
+++ b/peWorkerDockerfile
@@ -3,6 +3,7 @@ RUN mkdir /decompilers
 WORKDIR /decompilers
 ENV HOME /home/root
 COPY requirements_worker.txt /tmp/requirements_worker.txt
+COPY requirements_test.txt /tmp/requirements_test.txt
 RUN pip install --upgrade pip && \
     pip --retries 10 install -r /tmp/requirements_worker.txt
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,7 @@ django-redis==4.10.0
 pyecharts==1.5.1
 bottleneck==1.2.1
 drf-yasg==1.17.0
-# coverage==4.5.4
-coverage
+coverage==7.6.1
 pycodestyle==2.5.0
 pyseaweed==1.0.2
 django-request==1.5.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,8 @@ django-redis==4.10.0
 pyecharts==1.5.1
 bottleneck==1.2.1
 drf-yasg==1.17.0
-coverage==4.5.4
+# coverage==4.5.4
+coverage
 pycodestyle==2.5.0
 pyseaweed==1.0.2
 django-request==1.5.5

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,2 @@
-coverage==7.6.1
+coverage==6.5.0
 pycodestyle==2.5.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,2 @@
-coverage==6.5.0
+coverage==7.2.7  # last version to support python 3.7
 pycodestyle==2.5.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,2 @@
-coverage==4.5.4
+coverage==7.6.1
 pycodestyle==2.5.0

--- a/templateWorkerDockerfile
+++ b/templateWorkerDockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7.4-stretch
-RUN mkdir /daas
-WORKDIR /daas
+RUN mkdir /decompilers
+WORKDIR /decompilers
 COPY requirements_worker.txt /tmp/requirements_worker.txt
 RUN pip install --upgrade pip && \
     pip --retries 10 install -r /tmp/requirements_worker.txt
@@ -25,3 +25,5 @@ RUN apt-get update && \
         zlibc && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
+
+RUN ln -Ts /decompilers/ /daas


### PR DESCRIPTION
Increasing daas coverage and unifying everything in a single report. 
- Modifying the sitecustomize.py, and adding an environmental variable we can get the coverage of the running API (which uses gunicorn)


Still missing the coverage of running workers when doing integration tests.