### PR TITLE
DAAS-210 update base image of docker containers to bullseye

### DIFF
--- a/apkWorkerDockerfile
+++ b/apkWorkerDockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-buster
+FROM python:3.7-bullseye
 RUN mkdir /decompilers
 WORKDIR /decompilers
 COPY requirements_worker.txt /tmp/requirements_worker.txt
@@ -17,15 +17,14 @@ RUN apt-get update && \
         xvfb \
         zenity \
         zlib1g \
-        zlib1g-dev \
-        zlibc && \
+        zlib1g-dev && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
 
 # Install OpenJDK-11
 RUN apt update && \
-    echo 'deb http://ftp.de.debian.org/debian buster main' >> /etc/apt/sources.list && \
+    echo 'deb http://ftp.de.debian.org/debian bullseye main' >> /etc/apt/sources.list && \
     apt update && \
     apt-get install --no-install-recommends -y openjdk-11-jdk && \
     rm -rf /var/lib/apt/lists/* && \
@@ -33,10 +32,8 @@ RUN apt update && \
 
 
 # Install apktool
-RUN apt update && \
-    apt-get install --no-install-recommends -y apktool=2.3.4-1 && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt-get clean
+RUN wget -q -O /usr/local/bin/apktool.jar https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_2.11.1.jar && \
+wget -q -O /usr/local/bin/apktool https://raw.githubusercontent.com/iBotPeaches/Apktool/master/scripts/linux/apktool && chmod +x /usr/local/bin/apktool && /usr/local/bin/apktool --version
 
 
 # Java decompilers

--- a/coverageDockerfile
+++ b/coverageDockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.0-buster AS base
+FROM python:3.8-bullseye AS base
 RUN mkdir /daas
 WORKDIR /daas
 # Install testing pip packages

--- a/flashWorkerDockerfile
+++ b/flashWorkerDockerfile
@@ -1,16 +1,10 @@
-FROM python:3.7.4-stretch
+FROM python:3.7-bullseye
 RUN mkdir /decompilers
 WORKDIR /decompilers
 COPY requirements_worker.txt /tmp/requirements_worker.txt
 COPY requirements_test.txt /tmp/requirements_test.txt
 RUN pip install --upgrade pip && \
     pip --retries 10 install -r /tmp/requirements_worker.txt
-
-# Update stretch repositories
-RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list && \
-sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list && \
-sed -i '/stretch-updates/d' /etc/apt/sources.list
-
 
 # Generic
 RUN apt-get update && \
@@ -22,8 +16,7 @@ RUN apt-get update && \
         xvfb \
         zenity \
         zlib1g \
-        zlib1g-dev \
-        zlibc && \
+        zlib1g-dev && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
@@ -32,15 +25,27 @@ RUN apt-get update && \
 RUN mkdir /jre
 ADD ./utils/jre /jre
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y swftools && \
-    apt-get install --no-install-recommends -y \
-        java-common \
-        libasound2 \
-        libgl1 \
-        libxtst6 \
-        libxxf86vm1 && \
-    rm -rf /var/lib/apt/lists/* && \
-    apt-get clean
+	# swftools
+	apt install -y build-essential libfreetype6-dev libjpeg-dev zlib1g-dev libmp3lame0 && \
+	git clone https://github.com/flanter21/swftools.git && \
+	cd swftools && \
+	git checkout master && \
+	autoreconf --install --force --include=m4 && \
+	autoupdate && \
+	autoconf && \
+	./configure && make || echo dummy_echo because of https://github.com/swftools/swftools/issues/12 && make && make install && \
+	cd .. && rm -rf swftools && \
+	apt-get install --no-install-recommends -y \
+	  java-common \
+	  libasound2 \
+	  libgl1 \
+	  libxtst6 \
+	  libxxf86vm1 \
+	  libgtk2.0-0 && \
+	rm -rf /var/lib/apt/lists/* && \
+	apt-get clean
+
+
 RUN dpkg -i /jre/oracle-java8-jre_8u161_amd64.deb && \
     rm -f -v /jre/oracle-java8-jre_8u161_amd64.deb && \
     rm -rf /var/lib/apt/lists/* && \

--- a/javaWorkerDockerfile
+++ b/javaWorkerDockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.4-buster
+FROM python:3.7-bullseye
 RUN mkdir /decompilers
 WORKDIR /decompilers
 COPY requirements_worker.txt /tmp/requirements_worker.txt
@@ -17,8 +17,7 @@ RUN apt-get update && \
         xvfb \
         zenity \
         zlib1g \
-        zlib1g-dev \
-        zlibc && \
+        zlib1g-dev && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
@@ -26,7 +25,7 @@ RUN apt-get update && \
 
 # Install OpenJDK-11
 RUN apt update && \
-    echo 'deb http://ftp.de.debian.org/debian buster main' >> /etc/apt/sources.list && \
+    echo 'deb http://ftp.de.debian.org/debian bullseye main' >> /etc/apt/sources.list && \
     apt update && \
     apt-get install --no-install-recommends -y openjdk-11-jdk && \
     rm -rf /var/lib/apt/lists/* && \

--- a/metaExtractorWorkerDockerfile
+++ b/metaExtractorWorkerDockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.0-buster
+FROM python:3.8-bullseye
 RUN mkdir /meta_extractor
 WORKDIR /meta_extractor
 COPY requirements_worker.txt /tmp/requirements_worker.txt

--- a/seaweedfsDockerfile
+++ b/seaweedfsDockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM debian:bullseye
 RUN mkdir /swfs && \
     mkdir /volume_data
 WORKDIR /swfs

--- a/templateWorkerDockerfile
+++ b/templateWorkerDockerfile
@@ -1,14 +1,9 @@
-FROM python:3.7.4-stretch
+FROM python:3.7-bullseye
 RUN mkdir /decompilers
 WORKDIR /decompilers
 COPY requirements_worker.txt /tmp/requirements_worker.txt
 RUN pip install --upgrade pip && \
     pip --retries 10 install -r /tmp/requirements_worker.txt
-
-# Update stretch repositories
-RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list && \
-sed -i 's|security.debian.org|archive.debian.org/|g' /etc/apt/sources.list && \
-sed -i '/stretch-updates/d' /etc/apt/sources.list
 
 
 # Generic
@@ -21,8 +16,7 @@ RUN apt-get update && \
         xvfb \
         zenity \
         zlib1g \
-        zlib1g-dev \
-        zlibc && \
+        zlib1g-dev && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 


### PR DESCRIPTION
Updated:
- apkWorkerDockerfile from 3.7.4-buster to 3.7-bullseye
- coverageDockerfile from 3.8.0-buster to 3.8-bullseye
- flashWorkerDockerfile from 3.7.4-stretch to 3.7-bullseye
- javaWorkerDockerfile from 3.7.4-buster to 3.7-bullseye
- metaExtractorWorkerDockerfile from 3.8.0-buster to 3.8-bullseye
- seaweedfsDockerfile from debian:buster to debian:bullseye
- templateWorkerDockerfile from 3.7.4-stretch to 3.7-bullseye

Not updated:
- peWorkerDockerfile already on bullseye (3.7-bullseye)