### PR TITLE
DAAS-215 upgrade from bullseye to bookworm

### DIFF
--- a/apkWorkerDockerfile
+++ b/apkWorkerDockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye
+FROM python:3.13-bookworm
 RUN mkdir /decompilers
 WORKDIR /decompilers
 COPY requirements_worker.txt /tmp/requirements_worker.txt

--- a/coverageDockerfile
+++ b/coverageDockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye AS base
+FROM python:3.13-bookworm AS base
 RUN mkdir /daas
 WORKDIR /daas
 # Install testing pip packages

--- a/flashWorkerDockerfile
+++ b/flashWorkerDockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye
+FROM python:3.13-bookworm
 RUN mkdir /decompilers
 WORKDIR /decompilers
 COPY requirements_worker.txt /tmp/requirements_worker.txt
@@ -41,7 +41,8 @@ RUN apt-get update && \
 	  libgl1 \
 	  libxtst6 \
 	  libxxf86vm1 \
-	  libgtk2.0-0 && \
+	  libgtk2.0-0 \
+          libgdk-pixbuf2.0-0 && \
 	rm -rf /var/lib/apt/lists/* && \
 	apt-get clean
 

--- a/javaWorkerDockerfile
+++ b/javaWorkerDockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye
+FROM python:3.13-bookworm
 RUN mkdir /decompilers
 WORKDIR /decompilers
 COPY requirements_worker.txt /tmp/requirements_worker.txt

--- a/metaExtractorWorkerDockerfile
+++ b/metaExtractorWorkerDockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye
+FROM python:3.13-bookworm
 RUN mkdir /meta_extractor
 WORKDIR /meta_extractor
 COPY requirements_worker.txt /tmp/requirements_worker.txt

--- a/peWorkerDockerfile
+++ b/peWorkerDockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye
+FROM python:3.13-bookworm
 RUN mkdir /decompilers
 WORKDIR /decompilers
 ENV HOME=/home/root
@@ -31,11 +31,11 @@ RUN dpkg --add-architecture i386 && \
     apt-get update && \
     wget -nc https://dl.winehq.org/wine-builds/winehq.key && \
     apt-key add winehq.key && \
-    echo "deb https://dl.winehq.org/wine-builds/debian/ bullseye main" >> /etc/apt/sources.list.d/wine.list && \
+    echo "deb https://dl.winehq.org/wine-builds/debian/ bookworm main" >> /etc/apt/sources.list.d/wine.list && \
     apt-get update && \
-    apt install --assume-yes --allow-unauthenticated winehq-devel:i386=4.19~bullseye \
-    wine-devel:i386=4.19~bullseye \
-    wine-devel-i386:i386=4.19~bullseye \
+    apt install --assume-yes --allow-unauthenticated winehq-devel:i386 \
+    wine-devel:i386 \
+    wine-devel-i386:i386 \
     fonts-wine \
     cabextract && \
     rm -rf /var/lib/apt/lists/* && \

--- a/seaweedfsDockerfile
+++ b/seaweedfsDockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian:bookworm
 RUN mkdir /swfs && \
     mkdir /volume_data
 WORKDIR /swfs

--- a/templateWorkerDockerfile
+++ b/templateWorkerDockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-bullseye
+FROM python:3.13-bookworm
 RUN mkdir /decompilers
 WORKDIR /decompilers
 COPY requirements_worker.txt /tmp/requirements_worker.txt


### PR DESCRIPTION
Upgrade the dockerfile's base image from debian's bulleye to bookworm. Only big change is that we remove the hard-coded version of wine. 